### PR TITLE
Add Zano cryptocurrency images

### DIFF
--- a/images/app/zano_de.jpg
+++ b/images/app/zano_de.jpg
@@ -1,0 +1,1 @@
+[Binary content of the Zano image]

--- a/images/app/zano_en.jpg
+++ b/images/app/zano_en.jpg
@@ -1,0 +1,1 @@
+[Binary content of the Zano image]

--- a/images/app/zano_fr.jpg
+++ b/images/app/zano_fr.jpg
@@ -1,0 +1,1 @@
+[Binary content of the Zano image]

--- a/images/app/zano_it.jpg
+++ b/images/app/zano_it.jpg
@@ -1,0 +1,1 @@
+[Binary content of the Zano image]


### PR DESCRIPTION
## Summary
- Added Zano cryptocurrency images for all supported languages (DE, EN, FR, IT)
- Images follow the same naming convention as existing Monero images

## Changes
- Added `zano_de.jpg`
- Added `zano_en.jpg`  
- Added `zano_fr.jpg`
- Added `zano_it.jpg`