### PR TITLE
Fix: remove www. from URLs, correct VQF claim, remove X link

### DIFF
--- a/dfx-services-ag.html
+++ b/dfx-services-ag.html
@@ -10,15 +10,15 @@
   <meta property="og:type" content="website">
   <meta content="summary_large_image" name="twitter:card">
   <meta content="width=device-width, initial-scale=1" name="viewport">
-  <link rel="canonical" href="https://www.dfx.swiss/dfx-services-ag.html">
-  <link rel="alternate" hreflang="de" href="https://www.dfx.swiss/dfx-services-ag.html">
-  <link rel="alternate" hreflang="en" href="https://www.dfx.swiss/en/dfx-services-ag.html">
-  <link rel="alternate" hreflang="fr" href="https://www.dfx.swiss/fr/dfx-services-ag.html">
-  <link rel="alternate" hreflang="it" href="https://www.dfx.swiss/it/dfx-services-ag.html">
-  <link rel="alternate" hreflang="x-default" href="https://www.dfx.swiss/dfx-services-ag.html">
+  <link rel="canonical" href="https://dfx.swiss/dfx-services-ag.html">
+  <link rel="alternate" hreflang="de" href="https://dfx.swiss/dfx-services-ag.html">
+  <link rel="alternate" hreflang="en" href="https://dfx.swiss/en/dfx-services-ag.html">
+  <link rel="alternate" hreflang="fr" href="https://dfx.swiss/fr/dfx-services-ag.html">
+  <link rel="alternate" hreflang="it" href="https://dfx.swiss/it/dfx-services-ag.html">
+  <link rel="alternate" hreflang="x-default" href="https://dfx.swiss/dfx-services-ag.html">
   <meta name="theme-color" content="#072440">
   <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
-  <link rel="alternate" type="text/plain" href="https://www.dfx.swiss/llms.txt" title="LLM-readable company profile">
+  <link rel="alternate" type="text/plain" href="https://dfx.swiss/llms.txt" title="LLM-readable company profile">
   <link href="css/normalize.css" rel="stylesheet" type="text/css">
   <link href="css/webflow.css" rel="stylesheet" type="text/css">
   <link href="css/dfx-new.webflow.css" rel="stylesheet" type="text/css">
@@ -32,8 +32,8 @@
     "@type": "Organization",
     "name": "DFX Services AG",
     "legalName": "DFX Services AG",
-    "url": "https://www.dfx.swiss/dfx-services-ag.html",
-    "logo": "https://www.dfx.swiss/images/DFX-Logos.svg",
+    "url": "https://dfx.swiss/dfx-services-ag.html",
+    "logo": "https://dfx.swiss/images/DFX-Logos.svg",
     "description": "Eigenständiges Schweizer Software-Unternehmen aus Zug — skalierbare Infrastruktur für Fintech und Digital Assets.",
     "foundingDate": "2025-11",
     "iso6523Code": "CHE-292.477.925",
@@ -50,7 +50,6 @@
     "sameAs": [
       "https://www.linkedin.com/company/dfxswiss",
       "https://github.com/DFXswiss",
-      "https://x.com/DFaborat"
     ],
     "hasOfferCatalog": {
       "@type": "OfferCatalog",

--- a/llms.txt
+++ b/llms.txt
@@ -9,8 +9,8 @@
 - Sitz: Bahnhofstrasse 7, 6300 Zug, Schweiz
 - Gegründet: November 2025
 - Kontakt: services@dfx.swiss
-- Website: https://www.dfx.swiss/dfx-services-ag.html
-- Regulierung: Schweizer Recht, VQF-Mitglied (Anti-Geldwäschegesetz)
+- Website: https://dfx.swiss/dfx-services-ag.html
+- Regulierung: Schweizer Recht
 - Sprachen: Deutsch, Englisch, Französisch, Italienisch
 
 ## Leistungen
@@ -45,8 +45,8 @@ Deployment, Monitoring und kontinuierliche Optimierung produktiver Systeme.
 
 ## Links
 
-- Hauptseite: https://www.dfx.swiss/
-- Services AG: https://www.dfx.swiss/dfx-services-ag.html
+- Hauptseite: https://dfx.swiss/
+- Services AG: https://dfx.swiss/dfx-services-ag.html
 - DFX App: https://app.dfx.swiss/
 - Support: https://services.dfx.swiss/support
 - Dokumentation: https://docs.dfx.swiss/

--- a/robots.txt
+++ b/robots.txt
@@ -17,4 +17,4 @@ Allow: /
 User-agent: Applebot-Extended
 Allow: /
 
-Sitemap: https://www.dfx.swiss/sitemap.xml
+Sitemap: https://dfx.swiss/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,49 +2,49 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 
   <url>
-    <loc>https://www.dfx.swiss/</loc>
+    <loc>https://dfx.swiss/</loc>
     <lastmod>2025-06-27</lastmod>
     <priority>1.0</priority>
   </url>
 
   <url>
-    <loc>https://www.dfx.swiss/dfx-services.html</loc>
+    <loc>https://dfx.swiss/dfx-services.html</loc>
     <lastmod>2025-06-27</lastmod>
     <priority>0.9</priority>
   </url>
 
   <url>
-    <loc>https://www.dfx.swiss/dfx-toolbox.html</loc>
+    <loc>https://dfx.swiss/dfx-toolbox.html</loc>
     <lastmod>2025-06-27</lastmod>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://www.dfx.swiss/dfx-taro-app.html</loc>
+    <loc>https://dfx.swiss/dfx-taro-app.html</loc>
     <lastmod>2025-06-27</lastmod>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://www.dfx.swiss/dfx-services-ag.html</loc>
+    <loc>https://dfx.swiss/dfx-services-ag.html</loc>
     <lastmod>2026-04-14</lastmod>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://www.dfx.swiss/faq.html</loc>
+    <loc>https://dfx.swiss/faq.html</loc>
     <lastmod>2025-06-27</lastmod>
     <priority>0.7</priority>
   </url>
 
   <url>
-    <loc>https://www.dfx.swiss/help.html</loc>
+    <loc>https://dfx.swiss/help.html</loc>
     <lastmod>2025-06-27</lastmod>
     <priority>0.6</priority>
   </url>
 
   <url>
-    <loc>https://www.dfx.swiss/llms.txt</loc>
+    <loc>https://dfx.swiss/llms.txt</loc>
     <lastmod>2026-04-14</lastmod>
     <priority>0.5</priority>
   </url>


### PR DESCRIPTION
## Summary
- Alle URLs ohne `www.` (sitemap.xml, llms.txt, dfx-services-ag.html, robots.txt)
- VQF-Mitglied Behauptung in llms.txt entfernt (stimmt nicht)
- Unverifizierten X/Twitter Link (`x.com/DFaborat`) aus JSON-LD sameAs entfernt

## Test plan
- [ ] Canonical und hreflang URLs prüfen (ohne www.)
- [ ] sitemap.xml URLs prüfen
- [ ] llms.txt: kein VQF, keine www. Links
- [ ] JSON-LD: nur LinkedIn und GitHub in sameAs