### PR TITLE
Auto-PR-Workflow für joshua-Branch

### DIFF
--- a/.github/workflows/joshua-auto-pr.yaml
+++ b/.github/workflows/joshua-auto-pr.yaml
@@ -1,0 +1,72 @@
+name: Auto PR joshua to develop
+
+on:
+  push:
+    branches: [joshua]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: joshua-auto-pr
+  cancel-in-progress: false
+
+jobs:
+  create-joshua-pr:
+    name: Create joshua PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch develop branch
+        run: git fetch origin develop
+
+      - name: Check for existing PR
+        id: check-pr
+        run: |
+          PR_COUNT=$(gh pr list --base develop --head joshua --state open --json number --jq 'length')
+          echo "pr_exists=$([[ $PR_COUNT -gt 0 ]] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
+          echo "::notice::Open PRs from joshua to develop: $PR_COUNT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check for differences
+        id: check-diff
+        if: steps.check-pr.outputs.pr_exists == 'false'
+        run: |
+          DIFF_COUNT=$(git rev-list --count origin/develop..origin/joshua)
+          echo "has_changes=$([[ $DIFF_COUNT -gt 0 ]] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
+          echo "commit_count=$DIFF_COUNT" >> $GITHUB_OUTPUT
+          echo "::notice::Commits ahead of develop: $DIFF_COUNT"
+
+      - name: Create joshua PR
+        if: steps.check-pr.outputs.pr_exists == 'false' && steps.check-diff.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_COUNT: ${{ steps.check-diff.outputs.commit_count }}
+        run: |
+          printf '%s\n' \
+            "## Automatic PR: joshua -> develop" \
+            "" \
+            "This PR was automatically created after changes were pushed to the joshua branch." \
+            "" \
+            "Preview deployment: https://joshua.dfx.swiss" \
+            "" \
+            "**Commits:** ${COMMIT_COUNT} new commit(s)" \
+            "" \
+            "### Checklist" \
+            "- [ ] Review the preview on joshua.dfx.swiss" \
+            "- [ ] Verify CI passes" \
+            "- [ ] Approve and merge to deploy to dev.dfx.swiss" \
+            > /tmp/pr-body.md
+
+          gh pr create \
+            --base develop \
+            --head joshua \
+            --title "joshua -> develop" \
+            --body-file /tmp/pr-body.md


### PR DESCRIPTION
## Summary
- Neuer Workflow `joshua-auto-pr.yaml`: bei Push auf Branch `joshua` wird automatisch ein PR `joshua -> develop` angelegt (analog zum bestehenden `auto-release-pr.yaml` für `develop -> main`)
- Idempotent: skipt wenn bereits ein offener PR existiert oder keine neuen Commits vorliegen
- Preview-Hinweis auf `joshua.dfx.swiss` (Cloudflare Pages, separat in DFXswiss/server eingerichtet)

## Workflow
1. Joshua pusht direkt nach `joshua` (kein PR mehr)
2. Cloudflare Pages baut automatisch → live auf joshua.dfx.swiss
3. Workflow legt automatisch PR `joshua -> develop` an
4. Review/Merge wie gewohnt → dev.dfx.swiss

## Test plan
- [ ] PR mergen, dann Test-Commit auf `joshua` pushen
- [ ] Auto-PR `joshua -> develop` erscheint
- [ ] Zweiter Push: kein doppelter PR (idempotent)