### PR TITLE
Cloudflare Pages Deploy für joshua-Branch (Direct Upload)

### DIFF
--- a/.github/workflows/joshua-deploy.yaml
+++ b/.github/workflows/joshua-deploy.yaml
@@ -1,0 +1,41 @@
+name: Deploy joshua to Cloudflare Pages
+
+on:
+  push:
+    branches: [joshua]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: joshua-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: wrangler pages deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Wrangler
+        run: npm install -g wrangler@4
+
+      - name: Deploy to Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          wrangler pages deploy . \
+            --project-name=dfx-landing-page-joshua \
+            --branch=joshua \
+            --commit-hash=${{ github.sha }} \
+            --commit-message="${{ github.event.head_commit.message }}"


### PR DESCRIPTION
## Summary
- Neuer Workflow `joshua-deploy.yaml`: bei Push auf `joshua` deployed via `wrangler pages deploy` zu Cloudflare Pages → live auf joshua.dfx.swiss
- Direct Upload (kein GitHub-Connect-Pages-Projekt) — Cloudflare Terraform Provider v5 hat einen bestätigten Bug mit GitHub-source Pages projects (Issue #5176)
- Konsistent mit dem bitcoin-payments-alliance Pattern (auch Direct Upload)

## Voraussetzungen vor dem Mergen
1. Pages-Projekt `dfx-landing-page-joshua` in DFXswiss/server existiert (Direct Upload mode) — Release-PR dort mergen
2. Tainted Pages-Projekt im Cloudflare-Dashboard löschen
3. Repo-Secrets in DFXswiss/landing-page setzen:
   - `CLOUDFLARE_API_TOKEN` (account-scoped, Permission: Cloudflare Pages → Edit)
   - `CLOUDFLARE_ACCOUNT_ID` (1682758c7dcd36eba16a988f5c7fb285)

## Test plan
- [ ] Tainted Pages-Projekt im CF Dashboard gelöscht
- [ ] Server-Repo Release-PR gemerged (sauberes Direct-Upload-Project + Domain angelegt)
- [ ] CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID Secrets gesetzt
- [ ] Diesen PR mergen
- [ ] Test-Commit auf joshua → Workflow läuft → joshua.dfx.swiss zeigt aktuellen Stand