### PR TITLE
Add AASA for DFX Wallet passkeys

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,5 +1,10 @@
 RewriteEngine On
 
+# Apple App Site Association — must be served as application/json
+<Files "apple-app-site-association">
+  ForceType application/json
+</Files>
+
 # Weiterleitungen für das REF System zur API
 RewriteRule ^app$ https://api.dfx.swiss/v1/app [R=301,L]
 RewriteRule ^(.+)/app$ https://api.dfx.swiss/v1/app?orig=$1 [R=301,NC,L,QSA]

--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -1,0 +1,5 @@
+{
+  "webcredentials": {
+    "apps": ["3C4B2M9M9S.swiss.dfx.wallet"]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `/.well-known/apple-app-site-association` with `webcredentials` for `swiss.dfx.wallet`
- Required for passkey (WebAuthn PRF) creation/authentication in the DFX Wallet iOS app
- Configures `Content-Type: application/json` via `.htaccess` (Apache serves extensionless files as `text/plain` by default)

## Test plan
- [ ] After merge+deploy, verify: `curl -sI https://dfx.swiss/.well-known/apple-app-site-association` returns `Content-Type: application/json`
- [ ] Verify JSON: `curl -s https://dfx.swiss/.well-known/apple-app-site-association | jq .`
- [ ] Test passkey creation in DFX Wallet on a physical iOS device