### PR TITLE
Fix AASA Team ID to DFX AG organization

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -1,5 +1,5 @@
 {
   "webcredentials": {
-    "apps": ["3C4B2M9M9S.swiss.dfx.wallet"]
+    "apps": ["Y4QBY6387T.swiss.dfx.wallet"]
   }
 }


### PR DESCRIPTION
## Summary
- Fixes Team ID in AASA from `3C4B2M9M9S` (personal) to `Y4QBY6387T` (DFX AG organization)
- Without the correct Team ID, Apple rejects passkey association

## Test plan
- [ ] After deploy, verify: `curl -s https://dfx.swiss/.well-known/apple-app-site-association` shows `Y4QBY6387T`
- [ ] Test passkey creation on physical iOS device