### PR TITLE
Update AASA bundle ID to wallet.dfx.swiss

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -1,5 +1,5 @@
 {
   "webcredentials": {
-    "apps": ["Y4QBY6387T.swiss.dfx.wallet"]
+    "apps": ["Y4QBY6387T.wallet.dfx.swiss"]
   }
 }


### PR DESCRIPTION
## Summary
- Changes bundle ID in AASA from `swiss.dfx.wallet` to `wallet.dfx.swiss`
- Required because `swiss.dfx.wallet` was already registered on a personal developer account

## Test plan
- [ ] After deploy, verify: `curl -s https://dfx.swiss/.well-known/apple-app-site-association` shows `wallet.dfx.swiss`
- [ ] Test passkey creation on physical iOS device