### PR TITLE
fix(deploy): pass commit message via env var (multi-line safe)

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -33,9 +33,10 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           wrangler pages deploy . \
             --project-name=dfx-landing-page-dev \
             --branch=develop \
             --commit-hash=${{ github.sha }} \
-            --commit-message="${{ github.event.head_commit.message }}"
+            --commit-message="$COMMIT_MSG"

--- a/.github/workflows/prd.yaml
+++ b/.github/workflows/prd.yaml
@@ -33,9 +33,10 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           wrangler pages deploy . \
             --project-name=dfx-landing-page-prd \
             --branch=main \
             --commit-hash=${{ github.sha }} \
-            --commit-message="${{ github.event.head_commit.message }}"
+            --commit-message="$COMMIT_MSG"


### PR DESCRIPTION
Same fix as DFXswiss/docs#133 et al. — wrangler deploy step breaks when commit message contains quotes/newlines (e.g. revert commits, multi-line PR descriptions).

Failing run on this repo: 26474884882 (`Revert ... (#122)` — bash syntax error near unexpected token `(`).