### PR TITLE
fix(deploy): pass commit message via env var (cherry-pick of #123 → main)

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -33,9 +33,10 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           wrangler pages deploy . \
             --project-name=dfx-landing-page-dev \
             --branch=develop \
             --commit-hash=${{ github.sha }} \
-            --commit-message="${{ github.event.head_commit.message }}"
+            --commit-message="$COMMIT_MSG"

--- a/.github/workflows/prd.yaml
+++ b/.github/workflows/prd.yaml
@@ -33,9 +33,10 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           wrangler pages deploy . \
             --project-name=dfx-landing-page-prd \
             --branch=main \
             --commit-hash=${{ github.sha }} \
-            --commit-message="${{ github.event.head_commit.message }}"
+            --commit-message="$COMMIT_MSG"


### PR DESCRIPTION
Cherry-pick of #123 from develop onto main.

PR #118 (develop → main) is currently CONFLICTING because dev.yaml + prd.yaml diverged between develop (env-var pattern, fixed) and main (direct ${{ }} expansion, still has the multi-line-commit-message bug).

This brings the env-var fix to main directly. After merge, PR #118 becomes a no-op (develop and main inhaltlich identisch) and can be closed or merged trivially.