### PR TITLE
Make repo robots.txt the canonical permissive crawl policy

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -37,4 +37,7 @@ Allow: /
 User-agent: meta-externalagent
 Allow: /
 
+User-agent: PerplexityBot
+Allow: /
+
 Sitemap: https://dfx.swiss/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -1,20 +1,40 @@
+# robots.txt — DFX
+#
+# Public landing page. We explicitly WANT both search engines and AI agents to
+# crawl, index, and learn from this content. This file is version-controlled in
+# this repository and is the authoritative crawl policy for this site.
+#
+# Content signals: all uses are granted — search, AI input / retrieval-augmented
+# generation, and AI training. We deliberately do NOT signal ai-train=no.
+
 User-agent: *
 Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 
-# AI & LLM crawlers
+# Major AI crawlers are explicitly welcome. Some honor only their own named
+# record, so each is listed in addition to the wildcard group above.
+User-agent: ClaudeBot
+Allow: /
+
 User-agent: GPTBot
 Allow: /
 
-User-agent: Claude-Web
+User-agent: Google-Extended
 Allow: /
 
-User-agent: ChatGPT-User
+User-agent: CCBot
 Allow: /
 
-User-agent: PerplexityBot
+User-agent: Bytespider
+Allow: /
+
+User-agent: Amazonbot
 Allow: /
 
 User-agent: Applebot-Extended
+Allow: /
+
+User-agent: meta-externalagent
 Allow: /
 
 Sitemap: https://dfx.swiss/sitemap.xml


### PR DESCRIPTION
## What

Promotes the version-controlled `robots.txt` at the repo root to the authoritative, permissive crawl policy for the site.

- Allow all crawlers, including AI agents (no `ai-train=no`).
- Add an explicit `Content-Signal: search=yes, ai-input=yes, ai-train=yes` on the wildcard group, granting search, AI input / RAG, and AI training.
- List the major named AI crawler records (ClaudeBot, GPTBot, Google-Extended, CCBot, Bytespider, Amazonbot, Applebot-Extended, meta-externalagent) in addition to the wildcard group, since some crawlers only honor their own named record.
- Keep the `Sitemap:` line — `sitemap.xml` is present in this repo and served at the site root (HTTP 200).

## Why

We explicitly want both search engines and AI agents to crawl, index, and learn from this public content. Keeping the policy in this repo makes the intended crawl policy reviewable and version-controlled.

## Prior content

The previous root `robots.txt` already allowed all crawlers and named a few AI agents (GPTBot, Claude-Web, ChatGPT-User, PerplexityBot, Applebot-Extended) plus the Sitemap line, but had no content-signal and an inconsistent crawler list. This PR makes the allow-all-incl-AI intent explicit and broadens named coverage.

## Note on live effect

This domain is served via a CDN/edge zone that also fronts auth-gated subdomains. The live behavior of this file therefore additionally depends on the operator's separate edge-zone decision about that zone's "Block AI bots / Manage robots.txt" setting, which can shadow a repo-served `robots.txt`. Landing this PR makes the repo the canonical source; the edge setting must be aligned separately for the file to take effect publicly.

## Deploy / build

No build step — the site is a static deploy (`wrangler pages deploy .` from the repo root on push to the target branch). `robots.txt` ships as-is from the publish root next to `index.html`.